### PR TITLE
回帖折叠组件和副本专题报错修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
-
+#Webstrom
+.idea

--- a/js/init.js
+++ b/js/init.js
@@ -7,6 +7,7 @@ H.load([
 	{'responsive':head_conf.CDNROOT+'plugin/responsive.js'},
 	{'getRequest':head_conf.CDNROOT+'plugin/getRequest.js'},
 	{'fixSidebar':head_conf.CDNROOT+'plugin/fixSidebar.js'},
+    {'treeview':head_conf.CDNROOT+'plugin/jquery.treeview.js'},
 	{'header':head_conf.ROOT+'mod/header.js'},
 	{'footer':head_conf.CDNROOT+'mod/footer.js'},
 	{'dialog':head_conf.CDNROOT+'mod/dialog.js'},

--- a/js/mod/editor.js
+++ b/js/mod/editor.js
@@ -13,25 +13,5 @@ H.ready(['jquery'], function() {
 			$editorEX.addClass('showall')
 			$(this).hide()
 		})
-
-		//折叠展开更多楼层
-		var $tg = $("#u-tgpost"),
-            $ct = $(".c-fli").not(':first'),
-            $icon = $("#u-tgpost-icon"),
-            $tips = $("#u-tgpost-text"),
-            isFolderDefault = $(".tgpost-folder").length
-        $tg.on('click',function(){
-            $ct.fadeToggle('slow')
-            $icon.hasClass('on') ? $tips.text('展开') : $tips.text('折叠')
-            $icon.toggleClass('on')
-        })
-
-        if(isFolderDefault){
-            $ct.hide()
-        }else{
-            $icon.addClass('on')
-            $tips.text('折叠')
-        }
-
 	})
 })

--- a/js/mod/tgpost.js
+++ b/js/mod/tgpost.js
@@ -1,24 +1,23 @@
 H.ready(['jquery'], function(){
     jQuery(function($){
-
         var 
         	$tg = $("#u-tgpost"),
         	$ct = $(".c-fli").not(':first'),
         	$icon = $("#u-tgpost-icon"),
-        	$tips = $("#u-tgpost-text")
-            isFolderDefault = $(".tgpost-folder").length
+        	$tips = $("#u-tgpost-text"),
+            isFolderDefault = $(".tgpost-folder").length;
 
             $tg.on('click',function(){
-                $ct.fadeToggle('slow')
-                $icon.hasClass('on') ? $tips.text('展开') : $tips.text('折叠')
-                $icon.toggleClass('on')
+                $ct.fadeToggle('slow');
+                $icon.hasClass('on') ? $tips.text('展开') : $tips.text('折叠');
+                $icon.toggleClass('on');
             })
 
             if(isFolderDefault){
-                $ct.hide()
+                $ct.hide();
             }else{
-                $icon.addClass('on')
-                $tips.text('折叠')
+                $icon.addClass('on');
+                $tips.text('折叠');
             }
 
     })


### PR DESCRIPTION
回帖折叠组件修复[暂时无需优化]
这里主要是
js/mod/editor.js和 js/mod/tgpost.js 代码重复引起的。需要你再次确认其他地方是否两个都同时引用。或者重新合并成一个。删除tgpost.js文件


副本专题报错在与副本引用treeview时未正确指定js路径。
相关代码是：
```
js/page/pve-fam.js
```
然后在init.js增加定义即可